### PR TITLE
uses job_id instead of build_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 - psql -c 'CREATE DATABASE test_artifacts;' -U postgres
 - docker run -v $(pwd):/src:ro -t --rm --network=host docteurklein/sqitch:pgsql deploy ${DATABASE_URI}
 - docker run -v $(pwd):/src:ro -t --rm --network=host docteurklein/sqitch:pgsql verify ${DATABASE_URI}
-- psql -c "INSERT INTO artifacts_v2.artifacts (build_id, path, s3_object_key) VALUES ('foo', '/bar', 'fake_key');" -d test_artifacts -U postgres
+- psql -c "INSERT INTO artifacts_v2.artifacts (job_id, path, s3_object_key) VALUES ('foo', '/bar', 'fake_key');" -d test_artifacts -U postgres
 - openssl genrsa -out private_key.pem 2048
 - openssl rsa -in private_key.pem -pubout -out public_key.pem
 - export JWT_PRIVATE_KEY_PATH=$(pwd)/private_key.pem

--- a/db/deploy/artifacts_job_id.sql
+++ b/db/deploy/artifacts_job_id.sql
@@ -1,0 +1,10 @@
+-- Deploy artifacts:artifacts_job_id to pg
+-- requires: artifacts
+-- requires: appschema
+
+BEGIN;
+
+ALTER TABLE artifacts_v2.artifacts
+ADD job_id VARCHAR;
+
+COMMIT;

--- a/db/revert/artifacts_job_id.sql
+++ b/db/revert/artifacts_job_id.sql
@@ -1,0 +1,8 @@
+-- Revert artifacts:artifacts_job_id from pg
+
+BEGIN;
+
+ALTER TABLE artifacts_v2.artifacts
+DROP COLUMN job_id;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -4,3 +4,4 @@
 
 appschema 2017-02-03T15:27:55Z root <root@985ebcde5622> # schema artifacts_v2
 artifacts [appschema] 2017-02-03T16:00:40Z root <root@882d73ffce1d> # creates table to track artifacts meta info
+artifacts_job_id [artifacts appschema] 2017-02-22T20:55:55Z root <root@81a0bcb976f7> # add new column in table artifacts

--- a/db/verify/artifacts_job_id.sql
+++ b/db/verify/artifacts_job_id.sql
@@ -1,0 +1,9 @@
+-- Verify artifacts:artifacts_job_id on pg
+
+BEGIN;
+
+SELECT job_id
+    FROM artifacts_v2.artifacts
+    WHERE FALSE;
+
+ROLLBACK;

--- a/model/artifact.go
+++ b/model/artifact.go
@@ -3,7 +3,8 @@ package model
 // Artifact represents metainfo of user artifact
 type Artifact struct {
 	ID        int     `db:"artifact_id,pk"`
-	BuildID   *string `db:"build_id"`
+	BuildID   *string `db:"build_id"` // deprecated
+	JobID     *string `db:"job_id"`
 	Path      *string `db:"path"`
 	ObjectKey *string `db:"s3_object_key"`
 }

--- a/router/route.go
+++ b/router/route.go
@@ -24,7 +24,7 @@ func Routes() http.Handler {
 
 	buildBase := mux.NewRouter()
 
-	router.PathPrefix("/builds/{build_id}").Handler(n.With(
+	router.PathPrefix("/jobs/{job_id}").Handler(n.With(
 		negroni.Wrap(buildBase),
 	))
 

--- a/router/route_test.go
+++ b/router/route_test.go
@@ -44,10 +44,10 @@ func TestJWT(t *testing.T) {
 		})
 	})
 
-	g.Describe("URI /builds/foo", func() {
+	g.Describe("URI /jobs/foo", func() {
 
 		g.It("supports verb OPTIONS", func() {
-			req, _ := http.NewRequest("OPTIONS", "/builds/foo", nil)
+			req, _ := http.NewRequest("OPTIONS", "/jobs/foo", nil)
 			req.Header.Set("Origin", "http://foo.example.com")
 			resp := httptest.NewRecorder()
 			app.ServeHTTP(resp, req)
@@ -56,7 +56,7 @@ func TestJWT(t *testing.T) {
 		})
 
 		g.It("requires token", func() {
-			req, _ := http.NewRequest("GET", "/builds/foo", nil)
+			req, _ := http.NewRequest("GET", "/jobs/foo", nil)
 			resp := httptest.NewRecorder()
 			app.ServeHTTP(resp, req)
 
@@ -66,7 +66,7 @@ func TestJWT(t *testing.T) {
 		g.It("supports JWT token", func() {
 			jwtToken, _ := generateJWTToken()
 
-			req, _ := http.NewRequest("GET", "/builds/foo", nil)
+			req, _ := http.NewRequest("GET", "/jobs/foo", nil)
 			req.Header.Set("Authorization", "BEARER "+jwtToken)
 			resp := httptest.NewRecorder()
 			app.ServeHTTP(resp, req)
@@ -77,7 +77,7 @@ func TestJWT(t *testing.T) {
 		g.It("supports CORS headers", func() {
 			jwtToken, _ := generateJWTToken()
 
-			req, _ := http.NewRequest("GET", "/builds/foo", nil)
+			req, _ := http.NewRequest("GET", "/jobs/foo", nil)
 			req.Header.Set("Authorization", "BEARER "+jwtToken)
 			req.Header.Set("Origin", "http://foo.example.com")
 			resp := httptest.NewRecorder()

--- a/server/artifact.go
+++ b/server/artifact.go
@@ -32,7 +32,7 @@ func UploadArtifact(w http.ResponseWriter, r *http.Request) {
 		defer file.Close()
 	}
 
-	buildID := mux.Vars(r)["build_id"]
+	buildID := mux.Vars(r)["job_id"]
 
 	filename := header.Filename
 	objectKey := store.HashKey(buildID, filename)
@@ -64,7 +64,7 @@ func UploadArtifact(w http.ResponseWriter, r *http.Request) {
 
 // ListArtifacts lists artifact meta info
 func ListArtifacts(w http.ResponseWriter, r *http.Request) {
-	buildID := mux.Vars(r)["build_id"]
+	buildID := mux.Vars(r)["job_id"]
 
 	datastore := store.FromContext(r)
 
@@ -85,7 +85,7 @@ func GetArtifact(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	var (
-		buildID    = vars["build_id"]
+		buildID    = vars["job_id"]
 		artifactID = vars["artifact_id"]
 	)
 

--- a/server/artifact_test.go
+++ b/server/artifact_test.go
@@ -28,9 +28,9 @@ func createTestApp() *negroni.Negroni {
 	n.Use(store.WithStore())
 
 	router.Methods("GET").Path("/status").HandlerFunc(HealthCheck)
-	router.Methods("POST").Path("/upload/{build_id}").HandlerFunc(UploadArtifact)
-	router.Methods("GET").Path("/b/{build_id}").HandlerFunc(ListArtifacts)
-	router.Methods("GET").Path("/b/{build_id}/a/{artifact_id}").HandlerFunc(GetArtifact)
+	router.Methods("POST").Path("/jobs/{job_id}").HandlerFunc(UploadArtifact)
+	router.Methods("GET").Path("/b/{job_id}").HandlerFunc(ListArtifacts)
+	router.Methods("GET").Path("/b/{job_id}/a/{artifact_id}").HandlerFunc(GetArtifact)
 
 	n.UseHandler(router)
 
@@ -60,7 +60,7 @@ func TestHandlers(t *testing.T) {
 
 	g.Describe("upload artifact", func() {
 		g.It("responses client side error", func() {
-			req, _ := http.NewRequest("POST", "/upload/bar", nil)
+			req, _ := http.NewRequest("POST", "/jobs/bar", nil)
 			resp := httptest.NewRecorder()
 			app.ServeHTTP(resp, req)
 
@@ -86,7 +86,7 @@ func TestHandlers(t *testing.T) {
 
 			bodyWriter.Close()
 
-			req, _ := http.NewRequest("POST", "/upload/bar", &bodyBuffer)
+			req, _ := http.NewRequest("POST", "/jobs/bar", &bodyBuffer)
 			req.Header.Set("Content-Type", bodyWriter.FormDataContentType())
 
 			resp := httptest.NewRecorder()

--- a/store/pq.go
+++ b/store/pq.go
@@ -69,24 +69,24 @@ func FromContext(r *http.Request) *datastore {
 
 // CreateArtifact is for saving meta info
 func (db *datastore) CreateArtifact(artifact *model.Artifact) error {
-	_, err := db.Exec(`INSERT INTO artifacts_v2.artifacts (build_id, path, s3_object_key)
-		VALUES ($1, $2, $3)`, artifact.BuildID, artifact.Path, artifact.ObjectKey)
+	_, err := db.Exec(`INSERT INTO artifacts_v2.artifacts (job_id, path, s3_object_key)
+		VALUES ($1, $2, $3)`, artifact.JobID, artifact.Path, artifact.ObjectKey)
 
 	return err
 }
 
-func (db *datastore) RetrieveKeyOfArtifact(id int, buildID string) (string, error) {
+func (db *datastore) RetrieveKeyOfArtifact(id int, jobID string) (string, error) {
 	var objectKey string
 
 	err := db.QueryRow(`SELECT s3_object_key FROM artifacts_v2.artifacts
-		WHERE build_id = $1 AND artifact_id = $2`, buildID, id).Scan(&objectKey)
+		WHERE job_id = $1 AND artifact_id = $2`, jobID, id).Scan(&objectKey)
 
 	return objectKey, err
 }
 
-func (db *datastore) ListArtifacts(buildID string) ([]*model.Artifact, error) {
+func (db *datastore) ListArtifacts(jobID string) ([]*model.Artifact, error) {
 	rows, err := db.Query(`SELECT artifact_id, path FROM artifacts_v2.artifacts
-		WHERE build_id = $1`, buildID)
+		WHERE job_id = $1`, jobID)
 
 	if err != nil {
 		log.Fatal(err)
@@ -105,9 +105,9 @@ func (db *datastore) ListArtifacts(buildID string) ([]*model.Artifact, error) {
 
 		if err == nil {
 			artifacts = append(artifacts, &model.Artifact{
-				ID:      id,
-				BuildID: &buildID,
-				Path:    &path,
+				ID:    id,
+				JobID: &jobID,
+				Path:  &path,
 			})
 		}
 	}

--- a/store/pq_test.go
+++ b/store/pq_test.go
@@ -16,13 +16,13 @@ func openTestDB() *datastore {
 
 func mockArtifact() *model.Artifact {
 	var (
-		buildID = "foo"
-		path    = "bar"
-		key     = fakeKeyValue
+		jobID = "foo"
+		path  = "bar"
+		key   = fakeKeyValue
 	)
 
 	return &model.Artifact{
-		BuildID:   &buildID,
+		JobID:     &jobID,
 		Path:      &path,
 		ObjectKey: &key,
 	}


### PR DESCRIPTION
fixed addon `artifacts_v2` on a branch of my fork of `travis-build`: https://github.com/shawnzhu/travis-build/commit/9dfb689a0ebde90906e6d795e8d49a0fab2f5597

a break change on API:

`/builds/<build_id>/artifacts/*` -> `/jobs/<job_id>/artifacts/*` 

fixes #22 