### PR TITLE
drop column s3_object_key from table artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 - psql -c 'CREATE DATABASE test_artifacts;' -U postgres
 - docker run -v $(pwd):/src:ro -t --rm --network=host docteurklein/sqitch:pgsql deploy ${DATABASE_URI}
 - docker run -v $(pwd):/src:ro -t --rm --network=host docteurklein/sqitch:pgsql verify ${DATABASE_URI}
-- psql -c "INSERT INTO artifacts_v2.artifacts (job_id, path, s3_object_key) VALUES ('foo', '/bar', 'fake_key');" -d test_artifacts -U postgres
+- psql -c "INSERT INTO artifacts_v2.artifacts (job_id, path) VALUES ('foo', '/bar');" -d test_artifacts -U postgres
 - openssl genrsa -out private_key.pem 2048
 - openssl rsa -in private_key.pem -pubout -out public_key.pem
 - export JWT_PRIVATE_KEY_PATH=$(pwd)/private_key.pem

--- a/cmd/travis-artifacts/main.go
+++ b/cmd/travis-artifacts/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func server(c *cli.Context) error {
-	handler := router.Routes()
+	handler := router.Routes(c)
 
 	if c.String("server-cert") == "" {
 		return http.ListenAndServe(c.String("server-addr"), handler)
@@ -46,6 +46,16 @@ func app() *cli.App {
 			Name:   "server-key",
 			Usage:  "server TLS key",
 			EnvVar: "SERVER_KEY",
+		},
+		cli.StringFlag{
+			Name:   "db-url",
+			Usage:  "database URL",
+			EnvVar: "DB_URL",
+		},
+		cli.StringFlag{
+			Name:   "jwt-public-key",
+			Usage:  "RSA public key for JWT",
+			EnvVar: "JWT_PUBLIC_KEY",
 		},
 	}
 

--- a/cmd/travis-artifacts/main_test.go
+++ b/cmd/travis-artifacts/main_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/urfave/cli"
@@ -34,6 +34,7 @@ func TestCli(t *testing.T) {
 	g.Describe("Run ./travis-artifacts -h", func() {
 		w := &mockWriter{}
 		app := app()
+		var output string
 
 		g.Before(func() {
 			app.Action = func(c *cli.Context) error {
@@ -44,22 +45,25 @@ func TestCli(t *testing.T) {
 			app.Writer = w
 
 			err := app.Run([]string{"travis-artifacts", "-h"})
+			output = string(w.GetWritten())
 			g.Assert(err).Equal(nil)
 		})
 
 		g.It("shows usage", func() {
-			g.Assert(bytes.Contains(w.written, []byte(app.Usage)))
+			g.Assert(strings.Contains(output, app.Usage)).Equal(true)
 		})
 
 		params := [...]string{
 			"server-addr",
 			"server-cert",
 			"server-key",
+			"db-url",
+			"jwt-public-key",
 		}
 
 		for _, param := range params {
 			g.It(fmt.Sprintf("supports parameter %s", param), func() {
-				g.Assert(bytes.Contains(w.written, []byte(param)))
+				g.Assert(strings.Contains(output, param)).Equal(true)
 			})
 		}
 	})

--- a/db/deploy/artifacts_s3_object_key.sql
+++ b/db/deploy/artifacts_s3_object_key.sql
@@ -1,0 +1,10 @@
+-- Deploy artifacts:artifacts_s3_object_key to pg
+-- requires: artifacts
+-- requires: appschema
+
+BEGIN;
+
+ALTER TABLE artifacts_v2.artifacts
+DROP COLUMN s3_object_key;
+
+COMMIT;

--- a/db/revert/artifacts_s3_object_key.sql
+++ b/db/revert/artifacts_s3_object_key.sql
@@ -1,0 +1,8 @@
+-- Revert artifacts:artifacts_s3_object_key from pg
+
+BEGIN;
+
+ALTER TABLE artifacts_v2.artifacts
+ADD s3_object_key VARCHAR(1024);
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -5,3 +5,4 @@
 appschema 2017-02-03T15:27:55Z root <root@985ebcde5622> # schema artifacts_v2
 artifacts [appschema] 2017-02-03T16:00:40Z root <root@882d73ffce1d> # creates table to track artifacts meta info
 artifacts_job_id [artifacts appschema] 2017-02-22T20:55:55Z root <root@81a0bcb976f7> # add new column in table artifacts
+artifacts_s3_object_key 2017-02-24T18:34:07Z root <root@moby> # drop s3_object_key

--- a/db/verify/artifacts.sql
+++ b/db/verify/artifacts.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-SELECT build_id, path, s3_object_key
+SELECT build_id, path
     FROM artifacts_v2.artifacts
     WHERE FALSE;
 

--- a/db/verify/artifacts_s3_object_key.sql
+++ b/db/verify/artifacts_s3_object_key.sql
@@ -1,0 +1,11 @@
+-- Verify artifacts:artifacts_s3_object_key on pg
+
+BEGIN;
+
+SELECT
+    (SELECT count(*)
+        FROM information_schema.columns
+        WHERE table_schema = 'artifacts_v2' AND table_name = 'artifacts' AND column_name = 's3_object_key'
+    ) = 0;
+
+ROLLBACK;

--- a/model/artifact.go
+++ b/model/artifact.go
@@ -2,9 +2,8 @@ package model
 
 // Artifact represents metainfo of user artifact
 type Artifact struct {
-	ID        int     `db:"artifact_id,pk"`
-	BuildID   *string `db:"build_id"` // deprecated
-	JobID     *string `db:"job_id"`
-	Path      *string `db:"path"`
-	ObjectKey *string `db:"s3_object_key"`
+	ID      int     `db:"artifact_id,pk"`
+	BuildID *string `db:"build_id"` // deprecated
+	JobID   *string `db:"job_id"`
+	Path    *string `db:"path"`
 }

--- a/router/jwt.go
+++ b/router/jwt.go
@@ -1,18 +1,18 @@
 package router
 
 import (
-	"os"
-
 	"github.com/dgrijalva/jwt-go"
 
 	"github.com/auth0/go-jwt-middleware"
+	"github.com/urfave/cli"
 	"github.com/urfave/negroni"
 )
 
 // JWT returns a new negroni middleware instance authenticates request
 // validating JWT signature by a given public key.
-func JWT() negroni.HandlerFunc {
-	publicKeyPEM := []byte(os.Getenv("JWT_PUBLIC_KEY"))
+func JWT(c *cli.Context) negroni.HandlerFunc {
+
+	publicKeyPEM := []byte(c.String("jwt-public-key"))
 
 	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		return jwt.ParseRSAPublicKeyFromPEM(publicKeyPEM)

--- a/router/route.go
+++ b/router/route.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/urfave/cli"
 	"github.com/urfave/negroni"
 
 	"github.com/travis-ci/artifacts-v2/server"
@@ -11,15 +12,15 @@ import (
 )
 
 // Routes load middlewares
-func Routes() http.Handler {
+func Routes(c *cli.Context) http.Handler {
 	router := mux.NewRouter()
 
 	router.HandleFunc("/status", server.HealthCheck).Methods("GET")
 
 	n := negroni.New(
-		JWT(),
+		JWT(c),
 		CORS(),
-		store.WithStore(),
+		store.WithStore(c),
 	)
 
 	buildBase := mux.NewRouter()

--- a/router/route_test.go
+++ b/router/route_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"flag"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -9,12 +10,15 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/urfave/cli"
 
 	. "github.com/franela/goblin"
 )
 
 func createTestApp() http.Handler {
-	return Routes()
+	mockSet := flag.NewFlagSet("test", 0)
+	mockSet.String("jwt-public-key", os.Getenv("JWT_PUBLIC_KEY"), "")
+	return Routes(cli.NewContext(nil, mockSet, nil))
 }
 
 func generateJWTToken() (string, error) {

--- a/server/artifact_test.go
+++ b/server/artifact_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/travis-ci/artifacts-v2/store"
+	"github.com/urfave/cli"
 	"github.com/urfave/negroni"
 
 	. "github.com/franela/goblin"
@@ -24,8 +26,9 @@ import (
 func createTestApp() *negroni.Negroni {
 	router := mux.NewRouter()
 	n := negroni.New()
+	mockSet := flag.NewFlagSet("test", 0)
 
-	n.Use(store.WithStore())
+	n.Use(store.WithStore(cli.NewContext(nil, mockSet, nil)))
 
 	router.Methods("GET").Path("/status").HandlerFunc(HealthCheck)
 	router.Methods("POST").Path("/jobs/{job_id}").HandlerFunc(UploadArtifact)

--- a/store/pq.go
+++ b/store/pq.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"log"
 	"net/http"
-	"os"
 
+	"github.com/urfave/cli"
 	"github.com/urfave/negroni"
 
 	"github.com/travis-ci/artifacts-v2/model"
@@ -40,13 +40,13 @@ func open(driverName, dbConnURL string) *datastore {
 }
 
 // WithStore mixins datastore into request context
-func WithStore() negroni.HandlerFunc {
+func WithStore(c *cli.Context) negroni.HandlerFunc {
 	var (
 		dbURL string
 		store *datastore
 	)
 
-	if dbURL = os.Getenv("DB_URL"); dbURL == "" {
+	if dbURL = c.String("db-url"); dbURL == "" {
 		dbURL = defaultDBURL
 	}
 

--- a/store/pq.go
+++ b/store/pq.go
@@ -69,19 +69,26 @@ func FromContext(r *http.Request) *datastore {
 
 // CreateArtifact is for saving meta info
 func (db *datastore) CreateArtifact(artifact *model.Artifact) error {
-	_, err := db.Exec(`INSERT INTO artifacts_v2.artifacts (job_id, path, s3_object_key)
-		VALUES ($1, $2, $3)`, artifact.JobID, artifact.Path, artifact.ObjectKey)
+	_, err := db.Exec(`INSERT INTO artifacts_v2.artifacts (job_id, path)
+		VALUES ($1, $2)`, artifact.JobID, artifact.Path)
 
 	return err
 }
 
-func (db *datastore) RetrieveKeyOfArtifact(id int, jobID string) (string, error) {
-	var objectKey string
+func (db *datastore) RetrieveArtifact(artifactID int) (*model.Artifact, error) {
+	var (
+		jobID string
+		path  string
+	)
 
-	err := db.QueryRow(`SELECT s3_object_key FROM artifacts_v2.artifacts
-		WHERE job_id = $1 AND artifact_id = $2`, jobID, id).Scan(&objectKey)
+	err := db.QueryRow(`SELECT job_id, path FROM artifacts_v2.artifacts
+		WHERE artifact_id = $1`, artifactID).Scan(&jobID, &path)
 
-	return objectKey, err
+	return &model.Artifact{
+		ID:    artifactID,
+		JobID: &jobID,
+		Path:  &path,
+	}, err
 }
 
 func (db *datastore) ListArtifacts(jobID string) ([]*model.Artifact, error) {

--- a/store/pq_test.go
+++ b/store/pq_test.go
@@ -18,13 +18,11 @@ func mockArtifact() *model.Artifact {
 	var (
 		jobID = "foo"
 		path  = "bar"
-		key   = fakeKeyValue
 	)
 
 	return &model.Artifact{
-		JobID:     &jobID,
-		Path:      &path,
-		ObjectKey: &key,
+		JobID: &jobID,
+		Path:  &path,
 	}
 }
 
@@ -34,9 +32,11 @@ func TestDB(t *testing.T) {
 	db := openTestDB()
 	defer db.Close()
 
+	artifact := mockArtifact()
+
 	g.Describe("stores meta info", func() {
 		g.It("saves artifact meta info", func() {
-			err := db.CreateArtifact(mockArtifact())
+			err := db.CreateArtifact(artifact)
 
 			g.Assert(err).Equal(nil)
 		})
@@ -47,14 +47,14 @@ func TestDB(t *testing.T) {
 			g.Assert(err).Equal(nil)
 		})
 
-		g.It("retrieves object key of an artifact", func() {
-			rows, err := db.ListArtifacts("foo")
+		g.It("retrieves an artifact", func() {
+			rows, err := db.ListArtifacts(*artifact.JobID)
 
 			id := rows[len(rows)-1].ID
 
-			objectKey, err := db.RetrieveKeyOfArtifact(id, "foo")
+			firstArtifact, _ := db.RetrieveArtifact(id)
 
-			g.Assert(objectKey).Equal(fakeKeyValue)
+			g.Assert(firstArtifact.JobID).Equal(artifact.JobID)
 
 			g.Assert(err).Equal(nil)
 		})

--- a/store/s3.go
+++ b/store/s3.go
@@ -41,8 +41,8 @@ func newAWSSession() (*s3.S3, error) {
 }
 
 // HashKey generates object key from artifact meta info
-func HashKey(buildID string, path string) string {
-	data := []byte(fmt.Sprintf("%s-%s", buildID, path))
+func HashKey(jobID string, path string) string {
+	data := []byte(fmt.Sprintf("%s-%s", jobID, path))
 	hash := md5.Sum(data)
 	return hex.EncodeToString(hash[:])
 }
@@ -64,12 +64,11 @@ func PutArtifact(artifact *model.Artifact, file multipart.File) error {
 }
 
 // GetArtifact retrieves artifact content
-func GetArtifact(buildID string, key string) (*model.Artifact, error) {
+func GetArtifact(jobID string, key string) (*model.Artifact, error) {
 
 	return &model.Artifact{
-		BuildID:   &buildID,
-		Path:      &key,
-		ObjectKey: &key,
+		JobID: &jobID,
+		Path:  &key,
 	}, nil
 }
 

--- a/store/s3_test.go
+++ b/store/s3_test.go
@@ -4,23 +4,17 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/travis-ci/artifacts-v2/model"
-
 	. "github.com/franela/goblin"
 )
 
 func TestS3(t *testing.T) {
 	g := Goblin(t)
 
+	artifact := mockArtifact()
+
 	g.Describe("PutArtifact", func() {
 		g.It("throws error", func() {
-			buildID := "foo"
-			filename := "bar.tgz"
-
-			err := PutArtifact(&model.Artifact{
-				BuildID: &buildID,
-				Path:    &filename,
-			}, nil)
+			err := PutArtifact(artifact, nil)
 
 			if err == nil {
 				g.Assert(err).Equal(nil) // fail test
@@ -28,23 +22,9 @@ func TestS3(t *testing.T) {
 		})
 	})
 
-	g.Describe("GetArtifact", func() {
-		g.It("returns meta info", func() {
-			buildID := "foo"
-			key := "bar"
-
-			artifact, err := GetArtifact(buildID, key)
-
-			g.Assert(err).Equal(nil)
-			g.Assert(*artifact.ObjectKey).Equal(key)
-		})
-	})
-
 	g.Describe("GetObjectURL", func() {
 		g.It("returns url to download object", func() {
-			key := "bar"
-
-			rawURL, err := GetObjectURL(key)
+			rawURL, err := GetObjectURL(artifact)
 			g.Assert(err).Equal(nil)
 
 			objectURL, _ := url.Parse(rawURL)


### PR DESCRIPTION
fixes #23 

where the object key will be determined by both job_id and artifact's absolute file path.